### PR TITLE
Add support for displaying PR labels

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,7 @@ Optional query parameters:
  - `listinterval`: Update interval for the list of monitored repos in seconds (default: 900)
  - `interval`: Update interval for monitored repos in seconds (default: 60)
  - `filterusers`: Only show PRs from specific users, if set in config (default: false)
+ - `labels`: Show labels attached to each PR (true/false, default:false)
 
 The Gist should contain one or more JSON files with this syntax:
 ```json

--- a/fourth-wall.css
+++ b/fourth-wall.css
@@ -128,6 +128,14 @@ h2 {
         top: 10px;
     }
 
+    .label {
+        float: right;
+        border: 1px solid white;
+        margin-right: 10px;
+        padding-left: 5px;
+        padding-right: 5px;
+    }
+
     p.comments {
         float: right;
         clear: right;

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 <script src="javascript/list-items.js" type="text/javascript"></script>
 <script src="javascript/list-view.js" type="text/javascript"></script>
 <script src="javascript/status.js" type="text/javascript"></script>
+<script src="javascript/issue.js" type="text/javascript"></script>
 <script src="javascript/pull-view.js" type="text/javascript"></script>
 <script src="javascript/pull.js" type="text/javascript"></script>
 <script src="javascript/pulls.js" type="text/javascript"></script>

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -146,6 +146,6 @@
   );
   FourthWall.importantUsers = [];
 
-  FourthWall.showLables = FourthWall.getQueryVariable('labels') === 'true';
+  FourthWall.showLabels = FourthWall.getQueryVariable('labels') === 'true';
 
 })();

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -1,7 +1,7 @@
 (function () {
   "use strict";
   window.FourthWall = window.FourthWall || {};
-  
+
   FourthWall.importantUsers = [];
 
   FourthWall.getQueryVariables = function(search) {
@@ -145,5 +145,7 @@
     FourthWall.getQueryVariable('file')
   );
   FourthWall.importantUsers = [];
+
+  FourthWall.showLables = FourthWall.getQueryVariable('labels') === 'true';
 
 })();

--- a/javascript/issue.js
+++ b/javascript/issue.js
@@ -1,0 +1,31 @@
+(function () {
+  "use strict";
+  window.FourthWall = window.FourthWall || {};
+
+  FourthWall.Issue = Backbone.Model.extend({
+
+    initialize: function () {
+      this.on('change:sha', function () {
+        this.fetch();
+      }, this);
+    },
+
+    url: function () {
+      return [
+        this.get('baseUrl'),
+        this.get('userName'),
+        this.get('repo'),
+        'issues',
+        this.get('pullId')
+      ].join('/');
+    },
+
+    fetch: function() {
+      return FourthWall.overrideFetch.call(this, this.url());
+    },
+
+    parse: function (response) {
+      return response;
+    }
+  });
+}());

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -62,7 +62,7 @@
       }
 
       var labelsHTML = "";
-      if (FourthWall.showLables &&
+      if (FourthWall.showLabels &&
             this.model.issue.get('labels') &&
             this.model.issue.get('labels').length > 0) {
         var labels = this.model.issue.get('labels')

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -62,10 +62,13 @@
       }
 
       var labelsHTML = "";
-      if (this.model.issue.get('labels') && this.model.issue.get('labels').length > 0) {
+      if (FourthWall.showLables &&
+            this.model.issue.get('labels') &&
+            this.model.issue.get('labels').length > 0) {
         var labels = this.model.issue.get('labels')
         for (var i = 0; i < labels.length; i++) {
-            labelsHTML += '<div class="label" style="background-color: #' + labels[i].color + ';">' + labels[i].name + ' </div>';
+            labelsHTML += '<div class="label" style="background-color: #' +
+                            labels[i].color + ';">' + labels[i].name + ' </div>';
         }
       }
 

--- a/javascript/pull-view.js
+++ b/javascript/pull-view.js
@@ -61,6 +61,14 @@
         this.$el.addClass("under-review");
       }
 
+      var labelsHTML = "";
+      if (this.model.issue.get('labels') && this.model.issue.get('labels').length > 0) {
+        var labels = this.model.issue.get('labels')
+        for (var i = 0; i < labels.length; i++) {
+            labelsHTML += '<div class="label" style="background-color: #' + labels[i].color + ';">' + labels[i].name + ' </div>';
+        }
+      }
+
       this.$el.html([
         '<img class="avatar" src="', this.model.get('user').avatar_url, '" />',
         statusString,
@@ -70,6 +78,7 @@
         '">',
         this.secondsToTime(this.model.get('elapsed_time')),
         '</div>',
+        labelsHTML,
         '<p><a href="', this.model.get('html_url'), '">',
         '<span class="username">',this.model.get('user').login,'</span>',
         ': ',

--- a/javascript/pull.js
+++ b/javascript/pull.js
@@ -20,6 +20,12 @@
         repo: this.get('repo'),
         sha: this.get('head').sha
       });
+      this.issue = new FourthWall.Issue({
+        baseUrl: this.collection.baseUrl,
+        userName: this.collection.userName,
+        repo: this.get('repo'),
+        pullId: this.get('number')
+      });
       this.on('change:head', function () {
         this.status.set('sha', this.get('head').sha);
       }, this);
@@ -43,6 +49,7 @@
 
     fetch: function () {
       this.status.fetch();
+      this.issue.fetch();
       this.comment.fetch();
       this.info.fetch();
     },


### PR DESCRIPTION
Fetches each PR as a GitHub issue (required to get the labels array) and displays any labels found on the wall in their GitHub chosen colour.

Example screenshot:

<img width="1273" alt="screen shot 2016-12-08 at 00 14 41" src="https://cloud.githubusercontent.com/assets/14041600/20992380/b1c4f554-bcdb-11e6-9ba5-cfd831b42d38.png">
